### PR TITLE
get UserProfiles Except Partners And Agents

### DIFF
--- a/controller/adminController/userProfileController.js
+++ b/controller/adminController/userProfileController.js
@@ -250,6 +250,36 @@ export const getUserProfilesByRole = async (req, res) => {
   }
 };
 
+// Function to get user profiles except roles Partner or Agent
+export const getUserProfilesExcludingRoles = async (req, res) => {
+  try {
+    const excludedRoles = ["partner", "agent"];
+    
+    // Create case-insensitive regular expressions for each excluded role
+    const regexRoles = excludedRoles.map((role) => new RegExp(`^${role}$`, 'i'));
+    
+    const userProfiles = await UserProfileModel.find({
+      role: { $nin: regexRoles },
+    }).select('-password -originalPassword'); // Exclude password and originalPassword fields
+
+    const transformedUserProfiles = userProfiles.map((profile) => ({
+      teamId: profile._id,
+      teamName: profile.fullName,
+      ...profile.toObject(),
+    }));
+
+    res.status(200).json({
+      message: "User profiles retrieved successfully",
+      data: transformedUserProfiles,
+      status: "success",
+    });
+  } catch (error) {
+    res.status(500).json({
+      message: "Error retrieving user profiles",
+      error: error.message,
+    });
+  }
+};
 
 // get user profile by ID
 export const getUserProfileById = async (req, res) => {

--- a/routes/adminRoutes/userProfileRoutes.js
+++ b/routes/adminRoutes/userProfileRoutes.js
@@ -6,7 +6,8 @@ import {
     deleteUserProfile,
     getAllUserProfiles,
     getUserProfilesByRole,
-    checkEmailExists
+    checkEmailExists,
+    getUserProfilesExcludingRoles
 } from "../../controller/adminController/userProfileController.js";
 
 import logActivity from '../../middlewares/logActivity.js';
@@ -15,6 +16,7 @@ const router = express.Router();
 // User profile routes
 router.post("/",logActivity, createUserProfile);
 router.get("/byRole",logActivity, getUserProfilesByRole);
+router.get('/exclude-roles',logActivity,getUserProfilesExcludingRoles);
 router.get("/",logActivity, getAllUserProfiles);
 router.get('/check-email',logActivity,checkEmailExists); 
 router.get("/:id", logActivity,getUserProfileById);


### PR DESCRIPTION
This PR adds a new endpoint to fetch user profiles while excluding those with roles "Partner" or "Agent". The endpoint /api/userProfiles/exclude-roles includes teamId and teamName in the response for each user profile.